### PR TITLE
fix: Content-Type 헤더 중복 설정으로 인한 StatReport API 호출 실패 수정

### DIFF
--- a/java-sample/src/main/java/com/naver/searchad/api/rest/StatReports.java
+++ b/java-sample/src/main/java/com/naver/searchad/api/rest/StatReports.java
@@ -13,7 +13,6 @@ public class StatReports {
 	// create
 	public static StatReport create(RestClient rest, long customerId, String reportType, String statDate) throws Exception {
 		HttpResponse<String> response = rest.post("/stat-reports", customerId)
-				.header("Content-Type", "application/json")
 				.body("{\"reportTp\":\"" + reportType + "\", \"statDt\":\"" + statDate + "\"}")
 				.asString();
 

--- a/java-sample/src/main/java/com/naver/searchad/api/sample/StatReportSample.java
+++ b/java-sample/src/main/java/com/naver/searchad/api/sample/StatReportSample.java
@@ -21,7 +21,7 @@ public class StatReportSample {
 			RestClient rest = RestClient.of(baseUrl, apiKey, secretKey);
 
 			String reportType = "AD";
-			String statDate = "20160201";
+			String statDate = "20251001";
 
 			// 리포트 요청 POST /stat-reports
 			StatReport statReport = StatReports.create(rest, customerId, reportType, statDate);


### PR DESCRIPTION
StatReports.create() 메서드에서 Content-Type 헤더를 중복으로 설정하여 HTTP 요청 시 

"application/json;charset=UTF-8,application/json" 형태로 잘못된 헤더가 전송되던 문제를 수정했습니다.

문제 상황:
- StatReports.create()에서 .header("Content-Type", "application/json") 설정
- RestClient.post()에서 이미 .header("Content-Type", "application/json;charset=UTF-8") 설정
- 결과: 헤더 값이 "application/json;charset=UTF-8,application/json"로 중복 설정됨
- 서버에서 Invalid mime type 오류 발생 (HTTP 500 또는 400 에러) 였지만 , 임시로 서버측에서 허용되도록 수정함.

수정 내용:
- StatReports.java: create() 메서드에서 중복된 Content-Type 헤더 설정 제거
- RestClient.post()가 이미 올바른 Content-Type을 설정하므로 재설정 불필요

---
수정 후 POST 로그 
`Reqeust Content-Type 가 1개`

~~~
============ Request =============
POST /stat-reports HTTP/1.1
accept-encoding: gzip
Content-Type: application/json;charset=UTF-8
user-agent: unirest-java/1.3.11
X-API-KEY: xxxx
X-Customer: 1234
X-Signature: xxxx
~~~

기존 로그 
~~~
============ Request =============
POST /stat-reports HTTP/1.1
accept-encoding: gzip
Content-Type: application/json;charset=UTF-8
Content-Type: application/json
user-agent: unirest-java/1.3.11
X-API-KEY: xxxx
X-Customer: 1234
X-Signature: xxxx
~~~